### PR TITLE
Add session switch component across admission pages

### DIFF
--- a/ACUnified-prod/ACUnified.Portal/Pages/AdmissionDecisionFinalization/AdmissionDecisionFinalization.razor
+++ b/ACUnified-prod/ACUnified.Portal/Pages/AdmissionDecisionFinalization/AdmissionDecisionFinalization.razor
@@ -21,6 +21,7 @@
 @inject ILGARepository LGARepository
 @inject IDialogService DialogService
 @inject IProgramSetupRepository ProgramSetupRepository
+@inject IAcademicSessionRepository AcademicSessionRepository
 @inject IJSRuntime JSRuntime
 @using ACUnified.Business.IServices
 @inject ICsvExportServices CsvExportServices
@@ -29,6 +30,7 @@
 @attribute [Authorize(Roles = "AdmissionDecisionFinalization")] 
 <div class="ml-5 py-4">
     <MudContainer>
+        <SessionSelector @bind-SelectedSessionId="selectedSessionId" />
         <MudText Typo="Typo.h6">Admission Finalization</MudText>
           <MudButton ButtonType="ButtonType.Submit"
                                    Variant="Variant.Filled"
@@ -222,6 +224,8 @@
         private MudTable<ApplicationFormDto> table;
         private int totalItems;
         private string searchString = null;
+
+        private long selectedSessionId;
 
         public IEnumerable<BioDataDto> BioDataDto;
             public IEnumerable<AcademicQualificationDto> AcademicQualificationDto;

--- a/ACUnified-prod/ACUnified.Portal/Pages/AdmissionDecisionFinalization/Admittedstudents.razor
+++ b/ACUnified-prod/ACUnified.Portal/Pages/AdmissionDecisionFinalization/Admittedstudents.razor
@@ -14,7 +14,9 @@
 @using Microsoft.EntityFrameworkCore
 @inject IJSRuntime JSRuntime
 @inject IApplicationFormRepository ApplicationFormRepository
+@inject IAcademicSessionRepository AcademicSessionRepository
 @attribute [Authorize(Roles = "AdmissionDecisionFinalization")]
+<SessionSelector @bind-SelectedSessionId="selectedSessionId" />
 <RadzenButton Text="Export to CSV" Click="@ExportToCsv" />
 <RadzenDataGrid TItem="ApplicationFormDto" Data="@ApplicationFormDtos" AllowFiltering="true" AllowPaging="true" AllowSorting="true" PageSize="10" AllowSearching="true">
     <Columns>
@@ -30,6 +32,7 @@
 </RadzenDataGrid>
 @code {
     IEnumerable<ApplicationFormDto> ApplicationFormDtos;
+    private long selectedSessionId;
 
     protected override async Task OnInitializedAsync()
     {

--- a/ACUnified-prod/ACUnified.Portal/Pages/AdmissionDecisionFinalization/Dashboard.razor
+++ b/ACUnified-prod/ACUnified.Portal/Pages/AdmissionDecisionFinalization/Dashboard.razor
@@ -21,7 +21,8 @@
 @inject ILGARepository LGARepository
 @inject IDialogService DialogService
 @inject IProgramSetupRepository ProgramSetupRepository
- @attribute [Authorize(Roles = "AdmissionDecisionFinalization")] 
+@inject IAcademicSessionRepository AcademicSessionRepository
+ @attribute [Authorize(Roles = "AdmissionDecisionFinalization")]
 
 <MudContainer Class="mt-16 px-8" MaxWidth="MaxWidth.False">
     <MudGrid>
@@ -36,7 +37,9 @@
         <MudItem xs="12" sm="6">
             <MudGrid>
                 <MudItem xs="12">
-                    <MudPaper Elevation="2" Class="pa-4" Style="height:auto"></MudPaper>
+                    <MudPaper Elevation="2" Class="pa-4" Style="height:auto">
+                        <SessionSelector @bind-SelectedSessionId="selectedSessionId" />
+                    </MudPaper>
                      @if (ApplicationFormRankingsDTO != null){
                     <MudSimpleTable Style="overflow-x: auto;">
    <thead>
@@ -139,6 +142,8 @@ else
         private MudTable<ApplicationFormDto> table;
         private int totalItems;
         private string searchString = null;
+
+        private long selectedSessionId;
 
         public IEnumerable<BioDataDto> BioDataDto;
             public IEnumerable<AcademicQualificationDto> AcademicQualificationDto;

--- a/ACUnified-prod/ACUnified.Portal/Pages/AdmissionOfficer/AdmissionDecision.razor
+++ b/ACUnified-prod/ACUnified.Portal/Pages/AdmissionOfficer/AdmissionDecision.razor
@@ -15,6 +15,7 @@
 @inject ILGARepository LGARepository
 @inject ICountryRepository CountryRepository
 @inject IApplicationFormRepository ApplicationFormRepository
+@inject IAcademicSessionRepository AcademicSessionRepository
 @inject NavigationManager Navigation
 @inject UserManager<ApplicationUser> UserManager
 @inject SignInManager<ApplicationUser> SignInManager
@@ -28,6 +29,7 @@
 @attribute [Authorize(Roles = "AdmissionOffice")]
 <div class="ml-5 py-4">
     <MudContainer>
+        <SessionSelector @bind-SelectedSessionId="selectedSessionId" />
         <MudText Typo="Typo.h6">Admission Decision</MudText>
      <MudButton ButtonType="ButtonType.Submit"
                                    Variant="Variant.Filled"
@@ -223,6 +225,8 @@
         private int totalItems;
         private string searchString = null;
           IEnumerable<ApplicationFormDto> ApplicationFormDtos;
+
+        private long selectedSessionId;
 
         public IEnumerable<BioDataDto> BioDataDto;
         public NextOfKinDto  NextOfKinDto = new NextOfKinDto();

--- a/ACUnified-prod/ACUnified.Portal/Pages/AdmissionOfficer/Dashboard.razor
+++ b/ACUnified-prod/ACUnified.Portal/Pages/AdmissionOfficer/Dashboard.razor
@@ -22,6 +22,7 @@
 @inject SignInManager<ApplicationUser> SignInManager
 @inject ILGARepository LGARepository
 @inject IDialogService DialogService
+@inject IAcademicSessionRepository AcademicSessionRepository
 @attribute [Authorize(Roles = "AdmissionOffice")]
 
 <MudContainer Class="mt-16 px-8" MaxWidth="MaxWidth.False">
@@ -37,7 +38,9 @@
         <MudItem xs="12" sm="6">
             <MudGrid>
                 <MudItem xs="12">
-                    <MudPaper Elevation="2" Class="pa-4" Style="height:auto"></MudPaper>
+                    <MudPaper Elevation="2" Class="pa-4" Style="height:auto">
+                        <SessionSelector @bind-SelectedSessionId="selectedSessionId" />
+                    </MudPaper>
                     <MudSimpleTable Style="overflow-x: auto;">
     <thead>
         <tr>
@@ -142,6 +145,8 @@
         private MudTable<ApplicationFormDto> table;
         private int totalItems;
         private string searchString = null;
+
+        private long selectedSessionId;
 
         public IEnumerable<BioDataDto> BioDataDto;
         public NextOfKinDto  NextOfKinDto = new NextOfKinDto();

--- a/ACUnified-prod/ACUnified.Portal/Pages/AdmissionOfficerBTH/AdmissionDecision.razor
+++ b/ACUnified-prod/ACUnified.Portal/Pages/AdmissionOfficerBTH/AdmissionDecision.razor
@@ -20,9 +20,11 @@
 @inject SignInManager<ApplicationUser> SignInManager
 @inject ILGARepository LGARepository
 @inject IDialogService DialogService
+@inject IAcademicSessionRepository AcademicSessionRepository
 @attribute [Authorize(Roles = "AdmissionOfficeBTH")]
 <div class="ml-5 py-4">
     <MudContainer>
+        <SessionSelector @bind-SelectedSessionId="selectedSessionId" />
         <MudText Typo="Typo.h6">Admission Decision</MudText>
         <MudTable ServerData="@(new Func<TableState, Task<TableData<ApplicationFormDto>>>(ServerReload))"
                   Dense="true" Hover="true" @ref="table">
@@ -204,6 +206,8 @@
         private MudTable<ApplicationFormDto> table;
         private int totalItems;
         private string searchString = null;
+
+        private long selectedSessionId;
 
         public IEnumerable<BioDataDto> BioDataDto;
         public NextOfKinDto  NextOfKinDto = new NextOfKinDto();

--- a/ACUnified-prod/ACUnified.Portal/Pages/AdmissionOfficerBTH/Dashboard.razor
+++ b/ACUnified-prod/ACUnified.Portal/Pages/AdmissionOfficerBTH/Dashboard.razor
@@ -22,6 +22,7 @@
 @inject SignInManager<ApplicationUser> SignInManager
 @inject ILGARepository LGARepository
 @inject IDialogService DialogService
+@inject IAcademicSessionRepository AcademicSessionRepository
 @attribute [Authorize(Roles = "AdmissionOfficeBTH")]
 
 <MudContainer Class="mt-16 px-8" MaxWidth="MaxWidth.False">
@@ -37,7 +38,9 @@
         <MudItem xs="12" sm="6">
             <MudGrid>
                 <MudItem xs="12">
-                    <MudPaper Elevation="2" Class="pa-4" Style="height:auto"></MudPaper>
+                    <MudPaper Elevation="2" Class="pa-4" Style="height:auto">
+                        <SessionSelector @bind-SelectedSessionId="selectedSessionId" />
+                    </MudPaper>
                     <MudSimpleTable Style="overflow-x: auto;">
     <thead>
         <tr>
@@ -137,6 +140,8 @@
         private MudTable<ApplicationFormDto> table;
         private int totalItems;
         private string searchString = null;
+
+        private long selectedSessionId;
 
         public IEnumerable<BioDataDto> BioDataDto;
         public NextOfKinDto  NextOfKinDto = new NextOfKinDto();

--- a/ACUnified-prod/ACUnified.Portal/Shared/SessionSelector.razor
+++ b/ACUnified-prod/ACUnified.Portal/Shared/SessionSelector.razor
@@ -1,0 +1,40 @@
+@using ACUnified.Business.Repository.IRepository
+@using ACUnified.Data.DTOs
+@inject IAcademicSessionRepository AcademicSessionRepository
+@using Microsoft.AspNetCore.Components
+
+<MudSelect T="long" Label="Session" @bind-Value="SelectedSessionId" OnChange="SelectionChanged" Dense="true" Class="mb-2">
+    @if (Sessions != null)
+    {
+        foreach (var s in Sessions)
+        {
+            <MudSelectItem Value="@s.Id">@s.Name</MudSelectItem>
+        }
+    }
+</MudSelect>
+
+@code {
+    [Parameter]
+    public long SelectedSessionId { get; set; }
+
+    [Parameter]
+    public EventCallback<long> SelectedSessionIdChanged { get; set; }
+
+    private IEnumerable<SessionDto> Sessions;
+
+    protected override async Task OnInitializedAsync()
+    {
+        Sessions = await AcademicSessionRepository.GetAllSession();
+        if (Sessions != null && Sessions.Any() && SelectedSessionId == 0)
+        {
+            SelectedSessionId = Sessions.First().Id;
+            await SelectedSessionIdChanged.InvokeAsync(SelectedSessionId);
+        }
+    }
+
+    private async Task SelectionChanged(long value)
+    {
+        SelectedSessionId = value;
+        await SelectedSessionIdChanged.InvokeAsync(value);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `SessionSelector` component for picking academic session
- integrate `SessionSelector` on admission decision and dashboard pages

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fb50f5a348320926fed0dfa0b6b3b