### PR TITLE
Add session-aware rankings

### DIFF
--- a/ACUnified-prod/ACUnified.Business/Repository/ApplicationFormRepository.cs
+++ b/ACUnified-prod/ACUnified.Business/Repository/ApplicationFormRepository.cs
@@ -168,26 +168,32 @@ namespace ACUnified.Business.Repository
                 return null;
             }
         }
-        public async Task<IEnumerable<ApplicationFormRankingsDto>> GetApplicationFormsByAppliedCourses()
+        public async Task<IEnumerable<ApplicationFormRankingsDto>> GetApplicationFormsByAppliedCourses(long? sessionId = null)
         {
             IEnumerable<ApplicationFormRankingsDto> applicationFormRankings = new List<ApplicationFormRankingsDto>();
 
             using (var db = new ApplicationDbContext(dbOptions))
             {
-                applicationFormRankings = db.ApplicationForm
-                .Where(x => x.ApplicantStage == Data.Enum.ApplicationStage.Stage3)
-                .Join(
-                    db.AcademicQualification,
-                    x => x.AcademicQualificationId,
-                    aq => aq.Id,
-                    (x, aq) => new { aq.Choice1, aq.Id }
-                )
-                .GroupBy(dt => dt.Choice1)
-                .Select(g => new ApplicationFormRankingsDto
+                var query = db.ApplicationForm.Where(x => x.ApplicantStage == Data.Enum.ApplicationStage.Stage3);
+
+                if (sessionId != null)
                 {
-                    Choice1 = g.Key,
-                    Count = g.Count()
-                }).ToList();
+                    query = query.Where(x => x.SessionId == sessionId);
+                }
+
+                applicationFormRankings = query
+                    .Join(
+                        db.AcademicQualification,
+                        x => x.AcademicQualificationId,
+                        aq => aq.Id,
+                        (x, aq) => new { aq.Choice1, aq.Id }
+                    )
+                    .GroupBy(dt => dt.Choice1)
+                    .Select(g => new ApplicationFormRankingsDto
+                    {
+                        Choice1 = g.Key,
+                        Count = g.Count()
+                    }).ToList();
             }
             return applicationFormRankings;
         }
@@ -516,27 +522,34 @@ public async Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsDetailsReg
             }
         }
 
-        public async Task<IEnumerable<ApplicationFormRankingsDto>> GetApplicationFormsByAppliedCoursesBTH()
+        public async Task<IEnumerable<ApplicationFormRankingsDto>> GetApplicationFormsByAppliedCoursesBTH(long? sessionId = null)
         {
             IEnumerable<ApplicationFormRankingsDto> applicationFormRankings = new List<ApplicationFormRankingsDto>();
 
             using (var db = new ApplicationDbContext(dbOptions))
             {
-                applicationFormRankings = db.ApplicationForm.Include(x => x.Degree)
+                var query = db.ApplicationForm.Include(x => x.Degree)
                           .Where(y => y.Degree.Name == "BTHBA")
-                .Where(x => x.ApplicantStage == Data.Enum.ApplicationStage.Stage3)
-                .Join(
-                    db.AcademicQualification,
-                    x => x.AcademicQualificationId,
-                    aq => aq.Id,
-                    (x, aq) => new { aq.Choice1, aq.Id }
-                )
-                .GroupBy(dt => dt.Choice1)
-                .Select(g => new ApplicationFormRankingsDto
+                          .Where(x => x.ApplicantStage == Data.Enum.ApplicationStage.Stage3);
+
+                if (sessionId != null)
                 {
-                    Choice1 = g.Key,
-                    Count = g.Count()
-                }).ToList();
+                    query = query.Where(x => x.SessionId == sessionId);
+                }
+
+                applicationFormRankings = query
+                    .Join(
+                        db.AcademicQualification,
+                        x => x.AcademicQualificationId,
+                        aq => aq.Id,
+                        (x, aq) => new { aq.Choice1, aq.Id }
+                    )
+                    .GroupBy(dt => dt.Choice1)
+                    .Select(g => new ApplicationFormRankingsDto
+                    {
+                        Choice1 = g.Key,
+                        Count = g.Count()
+                    }).ToList();
             }
             return applicationFormRankings;
         }
@@ -748,27 +761,34 @@ public async Task<string> GetLastUsedNumber()
             }
         }
 
-        public async Task<IEnumerable<ApplicationFormRankingsDto>> GetApplicationFormsByAppliedCoursesJUPEB()
+        public async Task<IEnumerable<ApplicationFormRankingsDto>> GetApplicationFormsByAppliedCoursesJUPEB(long? sessionId = null)
         {
             IEnumerable<ApplicationFormRankingsDto> applicationFormRankings = new List<ApplicationFormRankingsDto>();
 
             using (var db = new ApplicationDbContext(dbOptions))
             {
-                applicationFormRankings = db.ApplicationForm.Include(x => x.Degree)
+                var query = db.ApplicationForm.Include(x => x.Degree)
                           .Where(y => y.Degree.Name == "JUPEB")
-                .Where(x => x.ApplicantStage == Data.Enum.ApplicationStage.Stage3)
-                .Join(
-                    db.AcademicQualification,
-                    x => x.AcademicQualificationId,
-                    aq => aq.Id,
-                    (x, aq) => new { aq.Choice1, aq.Id }
-                )
-                .GroupBy(dt => dt.Choice1)
-                .Select(g => new ApplicationFormRankingsDto
+                          .Where(x => x.ApplicantStage == Data.Enum.ApplicationStage.Stage3);
+
+                if (sessionId != null)
                 {
-                    Choice1 = g.Key,
-                    Count = g.Count()
-                }).ToList();
+                    query = query.Where(x => x.SessionId == sessionId);
+                }
+
+                applicationFormRankings = query
+                    .Join(
+                        db.AcademicQualification,
+                        x => x.AcademicQualificationId,
+                        aq => aq.Id,
+                        (x, aq) => new { aq.Choice1, aq.Id }
+                    )
+                    .GroupBy(dt => dt.Choice1)
+                    .Select(g => new ApplicationFormRankingsDto
+                    {
+                        Choice1 = g.Key,
+                        Count = g.Count()
+                    }).ToList();
             }
             return applicationFormRankings;
         }

--- a/ACUnified-prod/ACUnified.Business/Repository/IRepository/IApplicationFormRepository.cs
+++ b/ACUnified-prod/ACUnified.Business/Repository/IRepository/IApplicationFormRepository.cs
@@ -16,7 +16,7 @@ namespace ACUnified.Business.Repository.IRepository
 
         Task<IEnumerable<ApplicationFormDto>> GetAuthorizedApplicationForm();
         Task<IEnumerable<ApplicationFormDto>> GetFinalizedApplicationForm();
-        Task<IEnumerable<ApplicationFormRankingsDto>> GetApplicationFormsByAppliedCourses();
+        Task<IEnumerable<ApplicationFormRankingsDto>> GetApplicationFormsByAppliedCourses(long? sessionId = null);
         Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudents();
         Task<ApplicationFormDto> GetCompletedApplicationForm(string userId);
         Task<IEnumerable<ApplicationFormRankingsDto>> GetAdmittedStudentsReg();
@@ -28,7 +28,7 @@ namespace ACUnified.Business.Repository.IRepository
         Task<IEnumerable<ApplicationFormDto>> GetCompletedApplicationFormBTH();
         Task<IEnumerable<ApplicationFormDto>> GetAuthorizedApplicationFormBTH();
         Task<IEnumerable<ApplicationFormDto>> GetFinalizedApplicationFormBTH();
-        Task<IEnumerable<ApplicationFormRankingsDto>> GetApplicationFormsByAppliedCoursesBTH();
+        Task<IEnumerable<ApplicationFormRankingsDto>> GetApplicationFormsByAppliedCoursesBTH(long? sessionId = null);
         Task<IEnumerable<ApplicationFormRankingsDto>> GetAdmittedStudentsBTH();
          Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsDetailsBTH();
         //bth
@@ -38,7 +38,7 @@ namespace ACUnified.Business.Repository.IRepository
         Task<IEnumerable<ApplicationFormDto>> GetCompletedApplicationFormJUPEB();
         Task<IEnumerable<ApplicationFormDto>> GetAuthorizedApplicationFormJUPEB();
         Task<IEnumerable<ApplicationFormDto>> GetFinalizedApplicationFormJUPEB();
-        Task<IEnumerable<ApplicationFormRankingsDto>> GetApplicationFormsByAppliedCoursesJUPEB();
+        Task<IEnumerable<ApplicationFormRankingsDto>> GetApplicationFormsByAppliedCoursesJUPEB(long? sessionId = null);
         Task<IEnumerable<ApplicationFormRankingsDto>> GetAdmittedStudentsJUPEB();
          Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsDetailsJUPEB();
        //JUPEB

--- a/ACUnified-prod/ACUnified.Portal/Pages/AdmissionOfficer/Dashboard.razor
+++ b/ACUnified-prod/ACUnified.Portal/Pages/AdmissionOfficer/Dashboard.razor
@@ -39,7 +39,7 @@
             <MudGrid>
                 <MudItem xs="12">
                     <MudPaper Elevation="2" Class="pa-4" Style="height:auto">
-                        <SessionSelector @bind-SelectedSessionId="selectedSessionId" />
+                        <SessionSelector @bind-SelectedSessionId="selectedSessionId" SelectedSessionIdChanged="OnSessionChanged" />
                     </MudPaper>
                     <MudSimpleTable Style="overflow-x: auto;">
     <thead>
@@ -166,10 +166,16 @@
         @"English 12 ", *@
 
     };
+    private IEnumerable<SessionDto> sessions;
     protected override async Task OnInitializedAsync()
     {
-        BioDataDto=(await BiodataRepository.GetAllBioData());
-        ApplicationFormRankingsDTO = await ApplicationFormRepository.GetApplicationFormsByAppliedCourses();
+        BioDataDto = (await BiodataRepository.GetAllBioData());
+        sessions = await AcademicSessionRepository.GetAllSession();
+        if (sessions != null && sessions.Any())
+        {
+            selectedSessionId = sessions.First().Id;
+        }
+        ApplicationFormRankingsDTO = await ApplicationFormRepository.GetApplicationFormsByAppliedCourses(selectedSessionId);
 
         _loading = true;
         var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
@@ -242,4 +248,10 @@
         new ChartSeries() { Name = "PHD", Data = new double[] { 8, 6, 11,  } },
     };
     public string[] XAxisLabels = { "2020/2021", "2021/2022", "2022/2023" };
+
+    private async Task OnSessionChanged(long value)
+    {
+        selectedSessionId = value;
+        ApplicationFormRankingsDTO = await ApplicationFormRepository.GetApplicationFormsByAppliedCourses(selectedSessionId);
+    }
 }

--- a/ACUnified-prod/ACUnified.Portal/Pages/AdmissionOfficerBTH/Dashboard.razor
+++ b/ACUnified-prod/ACUnified.Portal/Pages/AdmissionOfficerBTH/Dashboard.razor
@@ -39,7 +39,7 @@
             <MudGrid>
                 <MudItem xs="12">
                     <MudPaper Elevation="2" Class="pa-4" Style="height:auto">
-                        <SessionSelector @bind-SelectedSessionId="selectedSessionId" />
+                        <SessionSelector @bind-SelectedSessionId="selectedSessionId" SelectedSessionIdChanged="OnSessionChanged" />
                     </MudPaper>
                     <MudSimpleTable Style="overflow-x: auto;">
     <thead>
@@ -142,6 +142,7 @@
         private string searchString = null;
 
         private long selectedSessionId;
+        private IEnumerable<SessionDto> sessions;
 
         public IEnumerable<BioDataDto> BioDataDto;
         public NextOfKinDto  NextOfKinDto = new NextOfKinDto();
@@ -161,10 +162,16 @@
         @"English 12 ", *@
 
     };
+    private IEnumerable<SessionDto> sessions;
     protected override async Task OnInitializedAsync()
     {
-        BioDataDto=(await BiodataRepository.GetAllBioData());
-        ApplicationFormRankingsDTO = await ApplicationFormRepository.GetApplicationFormsByAppliedCoursesBTH();
+        BioDataDto = (await BiodataRepository.GetAllBioData());
+        sessions = await AcademicSessionRepository.GetAllSession();
+        if (sessions != null && sessions.Any())
+        {
+            selectedSessionId = sessions.First().Id;
+        }
+        ApplicationFormRankingsDTO = await ApplicationFormRepository.GetApplicationFormsByAppliedCoursesBTH(selectedSessionId);
 
         _loading = true;
         var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
@@ -237,4 +244,10 @@
         new ChartSeries() { Name = "PHD", Data = new double[] { 8, 6, 11,  } },
     };
     public string[] XAxisLabels = { "2020/2021", "2021/2022", "2022/2023" };
+
+    private async Task OnSessionChanged(long value)
+    {
+        selectedSessionId = value;
+        ApplicationFormRankingsDTO = await ApplicationFormRepository.GetApplicationFormsByAppliedCoursesBTH(selectedSessionId);
+    }
 }


### PR DESCRIPTION
## Summary
- allow ranking queries to filter by session
- wire up session change events on admission dashboards

## Testing
- `dotnet build ACUnified.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fe8997dc08320b67c0a82dc41f74a