### PR TITLE
Add HTML template upload tool

### DIFF
--- a/ACUnified-prod/ACUnified.Business/Services/HTMLTemplateFileService.cs
+++ b/ACUnified-prod/ACUnified.Business/Services/HTMLTemplateFileService.cs
@@ -21,5 +21,16 @@ namespace ACUnified.Business.Services
            string fileloc=Path.Combine(_webHostEnvironment.ContentRootPath,filepath);
             return await File.ReadAllTextAsync(fileloc);
         }
+
+        public async Task SaveTemplateFileAsync(string filepath, string content)
+        {
+            var fileloc = Path.Combine(_webHostEnvironment.ContentRootPath, filepath);
+            var directory = Path.GetDirectoryName(fileloc);
+            if (!Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory!);
+            }
+            await File.WriteAllTextAsync(fileloc, content);
+        }
     }
 }

--- a/ACUnified-prod/ACUnified.Business/Services/IServices/IHTMLTemplateFileService.cs
+++ b/ACUnified-prod/ACUnified.Business/Services/IServices/IHTMLTemplateFileService.cs
@@ -9,5 +9,6 @@ namespace ACUnified.Business.Services.IServices
     public interface IHTMLTemplateFileService
     {
        Task<string> GetTemplateFileAsync(string filepath);
+       Task SaveTemplateFileAsync(string filepath, string content);
     }
 }

--- a/ACUnified-prod/ACUnified.Portal/Pages/ICT/TemplateManager.razor
+++ b/ACUnified-prod/ACUnified.Portal/Pages/ICT/TemplateManager.razor
@@ -1,0 +1,67 @@
+@page "/ict/template-upload"
+@layout ACUnifiedLayout
+@using System.Text.RegularExpressions
+@using Microsoft.AspNetCore.Components.Forms
+@inject IHTMLTemplateFileService TemplateService
+@inject ISnackbar Snackbar
+
+<h3>Upload Template</h3>
+<InputFile OnChange="OnFileChange" accept=".html,.htm" />
+
+@if (!string.IsNullOrEmpty(FileName))
+{
+    <MudText Typo="Typo.h6" Class="mt-3">Placeholders</MudText>
+    <MudTable Items="placeholders">
+        <HeaderContent>
+            <MudTh>Original</MudTh>
+            <MudTh>Replacement</MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd>@context.Original</MudTd>
+            <MudTd>
+                <MudTextField @bind-Value="context.Replacement" />
+            </MudTd>
+        </RowTemplate>
+    </MudTable>
+    <MudButton OnClick="SaveTemplate" Variant="Variant.Filled" Color="Color.Primary" Class="mt-2">Save Template</MudButton>
+}
+
+@code {
+    private string? FileName;
+    private string? fileContent;
+
+    private List<PlaceholderItem> placeholders = new();
+
+    private class PlaceholderItem
+    {
+        public string Original { get; set; } = string.Empty;
+        public string Replacement { get; set; } = string.Empty;
+    }
+
+    private async Task OnFileChange(InputFileChangeEventArgs e)
+    {
+        var file = e.File;
+        FileName = file.Name;
+        using var reader = new StreamReader(file.OpenReadStream());
+        fileContent = await reader.ReadToEndAsync();
+        var matches = Regex.Matches(fileContent!, "{{(.*?)}}");
+        placeholders = matches.Select(m => m.Value)
+                               .Distinct()
+                               .Select(p => new PlaceholderItem{Original=p, Replacement=p})
+                               .ToList();
+    }
+
+    private async Task SaveTemplate()
+    {
+        if (string.IsNullOrEmpty(fileContent) || string.IsNullOrEmpty(FileName))
+            return;
+        var content = fileContent;
+        foreach (var ph in placeholders)
+        {
+            content = content.Replace(ph.Original, ph.Replacement);
+        }
+        var path = Path.Combine("Templates", "Uploaded", FileName);
+        await TemplateService.SaveTemplateFileAsync(path, content);
+        Snackbar.Add("Template saved", Severity.Success);
+    }
+}

--- a/ACUnified-prod/ACUnified.Portal/Shared/UnifiedNavMenu.razor
+++ b/ACUnified-prod/ACUnified.Portal/Shared/UnifiedNavMenu.razor
@@ -169,9 +169,10 @@
             <MudNavLink Href="/ict/StudentCourseSummary">StudentCourseSummary</MudNavLink>   
        <MudNavLink Href="/ict/SemesterManagement">Semester Mgt</MudNavLink>   
              <MudNavLink Href="/ict/courses">Courses </MudNavLink> 
-             <MudNavLink Href="/ict/calculator">Calculator </MudNavLink> 
-               <MudNavLink Href="/ict/users">User Management</MudNavLink>
-                <MudNavLink Href="/ict/matriculation">Matriculation</MudNavLink>
+             <MudNavLink Href="/ict/calculator">Calculator </MudNavLink>
+              <MudNavLink Href="/ict/users">User Management</MudNavLink>
+               <MudNavLink Href="/ict/matriculation">Matriculation</MudNavLink>
+               <MudNavLink Href="/ict/template-upload">Template Upload</MudNavLink>
 
         </MudNavGroup>
         }


### PR DESCRIPTION
## Summary
- extend `IHTMLTemplateFileService` with a method for saving templates
- implement the save method in `HTMLTemplateFileService`
- add new Template Upload page for ICT staff
- link the new page in the Unified nav menu

## Testing
- `dotnet build` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686ffb16fc408320959a65772701efe5