### PR TITLE
Fix session filtering for admitted students tables

### DIFF
--- a/ACUnified-prod/ACUnified.Business/Repository/ApplicationFormRepository.cs
+++ b/ACUnified-prod/ACUnified.Business/Repository/ApplicationFormRepository.cs
@@ -256,7 +256,7 @@ namespace ACUnified.Business.Repository
     }
 }
 
-public async Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsDetailsReg()
+public async Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsDetailsReg(long? sessionId = null)
         {
             try
             {
@@ -275,9 +275,10 @@ public async Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsDetailsReg
                         .Include(x => x.NextOfKin)
                         .Include(x => x.References);
 
-                    if (activeSessionId != null)
+                    var filterSession = sessionId ?? activeSessionId;
+                    if (filterSession != null)
                     {
-                        query = query.Where(x => x.SessionId == activeSessionId);
+                        query = query.Where(x => x.SessionId == filterSession);
                     }
 
                     IEnumerable<ApplicationFormDto> ApplicationFormDtos =
@@ -584,7 +585,7 @@ public async Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsDetailsReg
 }
 
                 
-        public async Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsDetailsBTH()
+        public async Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsDetailsBTH(long? sessionId = null)
         {
             try
             {
@@ -603,9 +604,10 @@ public async Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsDetailsReg
                         .Include(x => x.NextOfKin)
                         .Include(x => x.References);
 
-                    if (activeSessionId != null)
+                    var filterSession = sessionId ?? activeSessionId;
+                    if (filterSession != null)
                     {
-                        query = query.Where(x => x.SessionId == activeSessionId);
+                        query = query.Where(x => x.SessionId == filterSession);
                     }
 
                     IEnumerable<ApplicationFormDto> ApplicationFormDtos =
@@ -823,7 +825,7 @@ public async Task<string> GetLastUsedNumber()
 }
 
                 
-        public async Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsDetailsJUPEB()
+        public async Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsDetailsJUPEB(long? sessionId = null)
         {
             try
             {
@@ -842,9 +844,10 @@ public async Task<string> GetLastUsedNumber()
                         .Include(x => x.NextOfKin)
                         .Include(x => x.References);
 
-                    if (activeSessionId != null)
+                    var filterSession = sessionId ?? activeSessionId;
+                    if (filterSession != null)
                     {
-                        query = query.Where(x => x.SessionId == activeSessionId);
+                        query = query.Where(x => x.SessionId == filterSession);
                     }
 
                     IEnumerable<ApplicationFormDto> ApplicationFormDtos =
@@ -1004,7 +1007,7 @@ public async Task<string> GetLastUsedNumber()
             return applicationFormRankings;
         }
 
-        public async Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsPG()
+        public async Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsPG(long? sessionId = null)
         {
             try
             {
@@ -1023,9 +1026,10 @@ public async Task<string> GetLastUsedNumber()
                         .Include(x => x.Degree)
                         .Where(y => y.Degree.Name == "MSC" || y.Degree.Name == "PHD" || y.Degree.Name == "PGD" || y.Degree.Name == "MBA" || y.Degree.Name == "DBA" || y.Degree.Name == "MA");
 
-                    if (activeSessionId != null)
+                    var filterSession = sessionId ?? activeSessionId;
+                    if (filterSession != null)
                     {
-                        query = query.Where(x => x.SessionId == activeSessionId);
+                        query = query.Where(x => x.SessionId == filterSession);
                     }
 
                     IEnumerable<ApplicationFormDto> ApplicationFormDtos =

--- a/ACUnified-prod/ACUnified.Business/Repository/IRepository/IApplicationFormRepository.cs
+++ b/ACUnified-prod/ACUnified.Business/Repository/IRepository/IApplicationFormRepository.cs
@@ -20,7 +20,7 @@ namespace ACUnified.Business.Repository.IRepository
         Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudents();
         Task<ApplicationFormDto> GetCompletedApplicationForm(string userId);
         Task<IEnumerable<ApplicationFormRankingsDto>> GetAdmittedStudentsReg();
-       Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsDetailsReg();
+       Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsDetailsReg(long? sessionId = null);
         //regular
 
         //bth
@@ -30,7 +30,7 @@ namespace ACUnified.Business.Repository.IRepository
         Task<IEnumerable<ApplicationFormDto>> GetFinalizedApplicationFormBTH();
         Task<IEnumerable<ApplicationFormRankingsDto>> GetApplicationFormsByAppliedCoursesBTH(long? sessionId = null);
         Task<IEnumerable<ApplicationFormRankingsDto>> GetAdmittedStudentsBTH();
-         Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsDetailsBTH();
+         Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsDetailsBTH(long? sessionId = null);
         //bth
          Task<string> GetLastUsedNumber();
         //JUPEB
@@ -40,7 +40,7 @@ namespace ACUnified.Business.Repository.IRepository
         Task<IEnumerable<ApplicationFormDto>> GetFinalizedApplicationFormJUPEB();
         Task<IEnumerable<ApplicationFormRankingsDto>> GetApplicationFormsByAppliedCoursesJUPEB(long? sessionId = null);
         Task<IEnumerable<ApplicationFormRankingsDto>> GetAdmittedStudentsJUPEB();
-         Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsDetailsJUPEB();
+         Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsDetailsJUPEB(long? sessionId = null);
        //JUPEB
 
         //PG
@@ -50,7 +50,7 @@ namespace ACUnified.Business.Repository.IRepository
         Task<IEnumerable<ApplicationFormDto>> GetAuthorizedApplicationFormPG();
         Task<IEnumerable<ApplicationFormDto>> GetFinalizedApplicationFormPG();
         Task<IEnumerable<ApplicationFormRankingsDto>> GetApplicationFormsByAppliedCoursesPG(long? sessionId = null);
-        Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsPG();
+        Task<IEnumerable<ApplicationFormDto>> GetAdmittedStudentsPG(long? sessionId = null);
         //PG
 
 

--- a/ACUnified-prod/ACUnified.Portal/Pages/AdmissionDecisionFinalization/Admittedstudents.razor
+++ b/ACUnified-prod/ACUnified.Portal/Pages/AdmissionDecisionFinalization/Admittedstudents.razor
@@ -16,7 +16,7 @@
 @inject IApplicationFormRepository ApplicationFormRepository
 @inject IAcademicSessionRepository AcademicSessionRepository
 @attribute [Authorize(Roles = "AdmissionDecisionFinalization")]
-<SessionSelector @bind-SelectedSessionId="selectedSessionId" />
+<SessionSelector SelectedSessionId="selectedSessionId" SelectedSessionIdChanged="OnSessionChanged" />
 <RadzenButton Text="Export to CSV" Click="@ExportToCsv" />
 <RadzenDataGrid TItem="ApplicationFormDto" Data="@ApplicationFormDtos" AllowFiltering="true" AllowPaging="true" AllowSorting="true" PageSize="10" AllowSearching="true">
     <Columns>
@@ -38,6 +38,13 @@
     {
         await base.OnInitializedAsync();
         ApplicationFormDtos = await ApplicationFormRepository.GetAdmittedStudentsDetailsReg();
+    }
+
+    private async Task OnSessionChanged(long value)
+    {
+        selectedSessionId = value;
+        ApplicationFormDtos = await ApplicationFormRepository.GetAdmittedStudentsDetailsReg(selectedSessionId);
+        await InvokeAsync(StateHasChanged);
     }
 
  private async Task ExportToCsv()

--- a/ACUnified-prod/ACUnified.Portal/Pages/AdmissionDecisionFinalizationBTH/Admittedstudents.razor
+++ b/ACUnified-prod/ACUnified.Portal/Pages/AdmissionDecisionFinalizationBTH/Admittedstudents.razor
@@ -14,7 +14,9 @@
 @using Microsoft.EntityFrameworkCore
 @inject IJSRuntime JSRuntime
 @inject IApplicationFormRepository ApplicationFormRepository
+@inject IAcademicSessionRepository AcademicSessionRepository
 @attribute [Authorize(Roles = "AdmissionDecisionFinalizationBTH")]
+<SessionSelector SelectedSessionId="selectedSessionId" SelectedSessionIdChanged="OnSessionChanged" />
 <RadzenButton Text="Export to CSV" Click="@ExportToCsv" />
 <RadzenDataGrid TItem="ApplicationFormDto" Data="@AdmittedStudents" AllowFiltering="true" AllowPaging="true" AllowSorting="true" PageSize="10">
     <Columns>
@@ -30,12 +32,20 @@
 </RadzenDataGrid>
 
 @code {
-       IEnumerable<ApplicationFormDto> AdmittedStudents;
+    IEnumerable<ApplicationFormDto> AdmittedStudents;
+    private long selectedSessionId;
 
     protected override async Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();
         AdmittedStudents = await ApplicationFormRepository.GetAdmittedStudentsDetailsBTH();
+    }
+
+    private async Task OnSessionChanged(long value)
+    {
+        selectedSessionId = value;
+        AdmittedStudents = await ApplicationFormRepository.GetAdmittedStudentsDetailsBTH(selectedSessionId);
+        await InvokeAsync(StateHasChanged);
     }
 
  private async Task ExportToCsv()

--- a/ACUnified-prod/ACUnified.Portal/Pages/AdmissionDecisionFinalizationJUPEB/Admittedstudents.razor
+++ b/ACUnified-prod/ACUnified.Portal/Pages/AdmissionDecisionFinalizationJUPEB/Admittedstudents.razor
@@ -14,7 +14,9 @@
 @using Microsoft.EntityFrameworkCore
 @inject IJSRuntime JSRuntime
 @inject IApplicationFormRepository ApplicationFormRepository
+@inject IAcademicSessionRepository AcademicSessionRepository
 @attribute [Authorize(Roles = "AdmissionDecisionFinalizationJUPEB")]
+<SessionSelector SelectedSessionId="selectedSessionId" SelectedSessionIdChanged="OnSessionChanged" />
 <RadzenButton Text="Export to CSV" Click="@ExportToCsv" />
 <RadzenDataGrid TItem="ApplicationFormDto" Data="@ApplicationFormDtos" AllowFiltering="true" AllowPaging="true" AllowSorting="true" PageSize="10" AllowSearching="true">
     <Columns>
@@ -30,11 +32,19 @@
 </RadzenDataGrid>
 @code {
     IEnumerable<ApplicationFormDto> ApplicationFormDtos;
+    private long selectedSessionId;
 
     protected override async Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();
         ApplicationFormDtos = await ApplicationFormRepository.GetAdmittedStudentsDetailsJUPEB();
+    }
+
+    private async Task OnSessionChanged(long value)
+    {
+        selectedSessionId = value;
+        ApplicationFormDtos = await ApplicationFormRepository.GetAdmittedStudentsDetailsJUPEB(selectedSessionId);
+        await InvokeAsync(StateHasChanged);
     }
 
  private async Task ExportToCsv()

--- a/ACUnified-prod/ACUnified.Portal/Pages/AdmissionDecisionFinalizationPG/Admittedstudents.razor
+++ b/ACUnified-prod/ACUnified.Portal/Pages/AdmissionDecisionFinalizationPG/Admittedstudents.razor
@@ -9,7 +9,9 @@
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.EntityFrameworkCore
 @inject IApplicationFormRepository ApplicationFormRepository
+@inject IAcademicSessionRepository AcademicSessionRepository
 @attribute [Authorize(Roles = "AdmissionDecisionFinalizationPG")]
+<SessionSelector SelectedSessionId="selectedSessionId" SelectedSessionIdChanged="OnSessionChanged" />
 
 <RadzenDataGrid TItem="ApplicationFormDto" Data="@ApplicationFormDtos" AllowFiltering="true" AllowPaging="true" AllowSorting="true" PageSize="10" AllowSearching="true">
     <Columns>
@@ -25,10 +27,18 @@
 
 @code {
     IEnumerable<ApplicationFormDto> ApplicationFormDtos;
+    private long selectedSessionId;
 
     protected override async Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();
         ApplicationFormDtos = await ApplicationFormRepository.GetAdmittedStudentsPG();
+    }
+
+    private async Task OnSessionChanged(long value)
+    {
+        selectedSessionId = value;
+        ApplicationFormDtos = await ApplicationFormRepository.GetAdmittedStudentsPG(selectedSessionId);
+        await InvokeAsync(StateHasChanged);
     }
 }

--- a/ACUnified-prod/ACUnified.Portal/Pages/AdmissionOfficer/Dashboard.razor
+++ b/ACUnified-prod/ACUnified.Portal/Pages/AdmissionOfficer/Dashboard.razor
@@ -39,7 +39,7 @@
             <MudGrid>
                 <MudItem xs="12">
                     <MudPaper Elevation="2" Class="pa-4" Style="height:auto">
-                        <SessionSelector @bind-SelectedSessionId="selectedSessionId" SelectedSessionIdChanged="OnSessionChanged" />
+                        <SessionSelector SelectedSessionId="selectedSessionId" SelectedSessionIdChanged="OnSessionChanged" />
                     </MudPaper>
                     <MudSimpleTable Style="overflow-x: auto;">
     <thead>
@@ -198,6 +198,10 @@
     private async Task<TableData<ApplicationFormDto>> ServerReload(TableState state)
     {
         IEnumerable<ApplicationFormDto> data = (await ApplicationFormRepository.GetCompletedApplicationForm()).ToList();
+        if (selectedSessionId > 0)
+        {
+            data = data.Where(x => x.SessionId == selectedSessionId).ToList();
+        }
         await Task.Delay(300);
 
         if (data != null)
@@ -253,5 +257,7 @@
     {
         selectedSessionId = value;
         ApplicationFormRankingsDTO = await ApplicationFormRepository.GetApplicationFormsByAppliedCourses(selectedSessionId);
+        await table.ReloadServerData();
+        await InvokeAsync(StateHasChanged);
     }
 }

--- a/ACUnified-prod/ACUnified.Portal/Pages/AdmissionOfficerBTH/AdmittedStudents.razor
+++ b/ACUnified-prod/ACUnified.Portal/Pages/AdmissionOfficerBTH/AdmittedStudents.razor
@@ -9,7 +9,9 @@
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.EntityFrameworkCore
 @inject IApplicationFormRepository ApplicationFormRepository
+@inject IAcademicSessionRepository AcademicSessionRepository
 @attribute [Authorize(Roles = "AdmissionOfficeBTH")]
+<SessionSelector SelectedSessionId="selectedSessionId" SelectedSessionIdChanged="OnSessionChanged" />
 
 <RadzenDataGrid TItem="ApplicationFormDto" Data="@ApplicationFormDtos" AllowFiltering="true" AllowPaging="true" AllowSorting="true" PageSize="10" AllowSearching="true">
     <Columns>
@@ -25,10 +27,18 @@
 
 @code {
     IEnumerable<ApplicationFormDto> ApplicationFormDtos;
+    private long selectedSessionId;
 
     protected override async Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();
         ApplicationFormDtos = await ApplicationFormRepository.GetAdmittedStudentsDetailsBTH();
+    }
+
+    private async Task OnSessionChanged(long value)
+    {
+        selectedSessionId = value;
+        ApplicationFormDtos = await ApplicationFormRepository.GetAdmittedStudentsDetailsBTH(selectedSessionId);
+        await InvokeAsync(StateHasChanged);
     }
 }

--- a/ACUnified-prod/ACUnified.Portal/Pages/AdmissionOfficerBTH/Dashboard.razor
+++ b/ACUnified-prod/ACUnified.Portal/Pages/AdmissionOfficerBTH/Dashboard.razor
@@ -39,7 +39,7 @@
             <MudGrid>
                 <MudItem xs="12">
                     <MudPaper Elevation="2" Class="pa-4" Style="height:auto">
-                        <SessionSelector @bind-SelectedSessionId="selectedSessionId" SelectedSessionIdChanged="OnSessionChanged" />
+                        <SessionSelector SelectedSessionId="selectedSessionId" SelectedSessionIdChanged="OnSessionChanged" />
                     </MudPaper>
                     <MudSimpleTable Style="overflow-x: auto;">
     <thead>
@@ -162,7 +162,6 @@
         @"English 12 ", *@
 
     };
-    private IEnumerable<SessionDto> sessions;
     protected override async Task OnInitializedAsync()
     {
         BioDataDto = (await BiodataRepository.GetAllBioData());
@@ -194,6 +193,10 @@
     private async Task<TableData<ApplicationFormDto>> ServerReload(TableState state)
     {
         IEnumerable<ApplicationFormDto> data = (await ApplicationFormRepository.GetCompletedApplicationFormBTH()).ToList();
+        if (selectedSessionId > 0)
+        {
+            data = data.Where(x => x.SessionId == selectedSessionId).ToList();
+        }
         await Task.Delay(300);
 
         if (data != null)
@@ -249,5 +252,7 @@
     {
         selectedSessionId = value;
         ApplicationFormRankingsDTO = await ApplicationFormRepository.GetApplicationFormsByAppliedCoursesBTH(selectedSessionId);
+        await table.ReloadServerData();
+        await InvokeAsync(StateHasChanged);
     }
 }

--- a/ACUnified-prod/ACUnified.Portal/Pages/AdmissionOfficerPG/Dashboard.razor
+++ b/ACUnified-prod/ACUnified.Portal/Pages/AdmissionOfficerPG/Dashboard.razor
@@ -201,6 +201,10 @@
     private async Task<TableData<ApplicationFormDto>> ServerReload(TableState state)
     {
         IEnumerable<ApplicationFormDto> data = (await ApplicationFormRepository.GetCompletedApplicationFormPG()).ToList();
+        if (selectedSessionId > 0)
+        {
+            data = data.Where(x => x.SessionId == selectedSessionId).ToList();
+        }
         await Task.Delay(300);
 
         if (data != null)
@@ -256,5 +260,7 @@
     {
         selectedSessionId = value;
         ApplicationFormRankingsDTO = await ApplicationFormRepository.GetApplicationFormsByAppliedCoursesPG(selectedSessionId);
+        await table.ReloadServerData();
+        await InvokeAsync(StateHasChanged);
     }
 }


### PR DESCRIPTION
## Summary
- allow session ID parameter for admitted student queries
- reload admitted student lists when session changes

## Testing
- `dotnet build ACUnified.Portal/ACUnified.Portal.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872814236c08320ba4e073386d4c69e